### PR TITLE
Add @types/node and tslib as devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/crypto-js": "^4.2.1",
         "@types/mapbox__vector-tile": "^1.3.4",
         "@types/mocha": "^10.0.6",
+        "@types/node": "^22.5.5",
         "@types/pbf": "^3.0.5",
         "@types/proj4": "^2.5.5",
         "@types/yargs": "^17.0.32",
@@ -45,6 +46,7 @@
         "rollup-plugin-executable": "^1.6.3",
         "rollup-plugin-modify": "^3.0.0",
         "ts-node": "^10.9.2",
+        "tslib": "^2.7.0",
         "typescript": "^5.3.3"
       },
       "engines": {
@@ -2897,11 +2899,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
+      "version": "22.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
+      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "dev": true,
-      "peer": true
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -8026,12 +8030,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true
     },
     "node_modules/turf-jsts": {
       "version": "1.2.3",
@@ -8092,6 +8094,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/unified": {
       "version": "10.1.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/crypto-js": "^4.2.1",
     "@types/mapbox__vector-tile": "^1.3.4",
     "@types/mocha": "^10.0.6",
+    "@types/node": "^22.5.5",
     "@types/pbf": "^3.0.5",
     "@types/proj4": "^2.5.5",
     "@types/yargs": "^17.0.32",
@@ -71,6 +72,7 @@
     "rollup-plugin-executable": "^1.6.3",
     "rollup-plugin-modify": "^3.0.0",
     "ts-node": "^10.9.2",
+    "tslib": "^2.7.0",
     "typescript": "^5.3.3"
   },
   "dependencies": {


### PR DESCRIPTION
First of all, thanks for this nice library!

When I execute `npm i` in my macOS Sonoma 14.7 (arm64) + Node.js 20.10.0 environment, I encountered the following error.
```zsh
% npm i
npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead

> query-mvt@1.0.2 prepare
> rollup -c rollup.config.mjs && tsc --emitDeclarationOnly -d --declarationDir dist --esModuleInterop src/index.ts


src/index.ts → dist/cjs/index.cjs...
[!] (plugin typescript) RollupError: [plugin typescript] @rollup/plugin-typescript: Could not find module 'tslib', which is required by this plugin. Is it installed?
    at getRollupError (/Users/sanak/Projects/geocoder/git/query-mvt/node_modules/rollup/dist/shared/parseAst.js:282:41)
    at Object.error (/Users/sanak/Projects/geocoder/git/query-mvt/node_modules/rollup/dist/shared/parseAst.js:278:42)
    at Object.error (/Users/sanak/Projects/geocoder/git/query-mvt/node_modules/rollup/dist/shared/rollup.js:804:32)
    at preflight (file:///Users/sanak/Projects/geocoder/git/query-mvt/node_modules/@rollup/plugin-typescript/dist/es/index.js:516:17)
    at Object.buildStart (file:///Users/sanak/Projects/geocoder/git/query-mvt/node_modules/@rollup/plugin-typescript/dist/es/index.js:766:13)
    at /Users/sanak/Projects/geocoder/git/query-mvt/node_modules/rollup/dist/shared/rollup.js:989:40
    at async Promise.all (index 0)
    at PluginDriver.hookParallel (/Users/sanak/Projects/geocoder/git/query-mvt/node_modules/rollup/dist/shared/rollup.js:917:9)
    at /Users/sanak/Projects/geocoder/git/query-mvt/node_modules/rollup/dist/shared/rollup.js:21003:13
    at catchUnfinishedHookActions (/Users/sanak/Projects/geocoder/git/query-mvt/node_modules/rollup/dist/shared/rollup.js:20558:16)


npm ERR! code 1
npm ERR! path /Users/sanak/Projects/geocoder/git/query-mvt
npm ERR! command failed
npm ERR! command sh -c rollup -c rollup.config.mjs && tsc --emitDeclarationOnly -d --declarationDir dist --esModuleInterop src/index.ts
```

And I noticed that `package-lock.json` has the following diff.
```diff
--- a/package-lock.json
+++ b/package-lock.json
@@ -2896,13 +2896,6 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
-    "node_modules/@types/node": {
-      "version": "18.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -8025,14 +8018,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/turf-jsts": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
```

From npm `@rollup/plugin-typescript` document, `typescript` and `tslib` seem to be installed as peer dependencies,
https://www.npmjs.com/package/@rollup/plugin-typescript
> Note that both `typescript` and `tslib` are peer dependencies of this plugin that need to be installed separately.

so I execute the following command, then `npm i` and `npm test` were successfully finished.
```zsh
npm i @types/node tslib --save-dev
```

I pushed the changes to this PR, so review this PR is really helpful. :bow: